### PR TITLE
Remove tailwind numbered colours

### DIFF
--- a/app/App.vue
+++ b/app/App.vue
@@ -11,15 +11,13 @@ const routes = router.getRoutes().filter((route) => route.children.length > 0)
     <nav
       id="nav-bar"
       class="sticky top-0 z-10 flex h-fit w-full justify-between border-b border-slate-400 bg-slate-100 backdrop-blur dark:border-white dark:bg-black">
-      <RouterLink
-        to="/"
-        class="p-4 text-xl text-gray-100 transition hover:text-white dark:text-primary-200 sm:text-3xl">
+      <RouterLink to="/">
         <img
           src="/public/images/logo.png"
           class="w-32"
           alt="Lumuix Logo" />
       </RouterLink>
-      <div class="my-auto mr-6 flex gap-2 font-bold text-black dark:text-primary-200">
+      <div class="dark:text-primary-foreground my-auto mr-6 flex gap-2 font-bold text-black">
         <a href="https://github.com/SethSharp/lumuix"> 1.0.0-alpha.10.3 </a>
         <LumuixModeToggle />
       </div>

--- a/app/views/getting-started/Styles.vue
+++ b/app/views/getting-started/Styles.vue
@@ -31,9 +31,10 @@
   @import '@sethsharp/lumuix/dist/types/presets/styles.css';
 
   :root {
-      --primary-500: 174 90% 31%;
-      // rest of HSL codes (primary-{50-950})
+      --primary: 173 80% 40%;;
+      --primary-foreground: 210 40% 98%;
   }
     </pre>
+    Note: You can overwrite styles for accent, destructive and secondary.
   </div>
 </template>

--- a/src/components/badge/Badge.vue
+++ b/src/components/badge/Badge.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import type { HTMLAttributes } from 'vue'
-import { type BadgeVariants, badgeVariants } from '.'
 import { cn } from '@/lib/utils'
+import { type BadgeVariants, badgeVariants } from '.'
 
 const props = defineProps<{
   variant?: BadgeVariants['variant']

--- a/src/components/badge/index.ts
+++ b/src/components/badge/index.ts
@@ -1,4 +1,4 @@
-import { type VariantProps, cva } from 'class-variance-authority'
+import { cva, type VariantProps } from 'class-variance-authority'
 
 export { default as Badge } from './Badge.vue'
 
@@ -8,9 +8,11 @@ export const badgeVariants = cva(
     variants: {
       variant: {
         default: 'border-transparent bg-slate-800 text-slate-50',
-        primary: 'border-transparent bg-primary-600 text-primary-50',
-        secondary: 'border-transparent bg-secondary-600 text-secondary-50',
-        destructive: 'border-transparent bg-destructive-600 text-destructive-50',
+        primary: 'border-transparent bg-primary text-primary-foreground hover:bg-primary/80',
+        secondary:
+          'border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80',
+        destructive:
+          'border-transparent bg-destructive text-destructive-foreground hover:bg-destructive/80',
         outline: 'text-foreground',
       },
     },

--- a/src/components/button/Button.vue
+++ b/src/components/button/Button.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import type { HTMLAttributes } from 'vue'
-import { Primitive, type PrimitiveProps } from 'radix-vue'
 import { cn } from '@/lib/utils'
+import { Primitive, type PrimitiveProps } from 'radix-vue'
 import { type ButtonVariants, buttonVariants } from '.'
 
 interface Props extends PrimitiveProps {
@@ -19,7 +19,8 @@ const props = withDefaults(defineProps<Props>(), {
   <Primitive
     :as="as"
     :as-child="asChild"
-    :class="cn(buttonVariants({ variant, size }), props.class)">
+    :class="cn(buttonVariants({ variant, size }), props.class)"
+  >
     <slot />
   </Primitive>
 </template>

--- a/src/components/button/index.ts
+++ b/src/components/button/index.ts
@@ -1,32 +1,27 @@
-import { type VariantProps, cva } from 'class-variance-authority'
+import { cva, type VariantProps } from 'class-variance-authority'
 
 export { default as Button } from './Button.vue'
 
 export const buttonVariants = cva(
-  'inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-950 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 dark:ring-offset-slate-950 dark:focus-visible:ring-slate-300',
+  'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
   {
     variants: {
       variant: {
         default:
           'bg-slate-800 text-slate-50 hover:bg-slate-800/90 dark:bg-slate-300 dark:text-slate-900 dark:hover:bg-slate-300/90',
-        primary:
-          'bg-primary-500 text-primary-50 hover:bg-primary-500/90 dark:bg-primary-800 dark:text-slate-100 dark:hover:bg-primary-800/90',
-        destructive:
-          'bg-destructive-500 text-slate-50 hover:bg-destructive-500/90 dark:bg-destructive-800 dark:text-slate-100 dark:hover:bg-destructive-800/90',
+        primary: 'bg-primary text-primary-foreground shadow hover:bg-primary/90',
+        destructive: 'bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90',
         outline:
-          'border border-slate-200 bg-white hover:bg-slate-200/90 hover:text-slate-900 dark:text-slate-200 dark:border-slate-800 dark:bg-slate-950 dark:hover:bg-slate-800 dark:hover:text-slate-50',
-        secondary:
-          'bg-secondary-400 text-secondary-100 hover:bg-secondary-400/90 dark:bg-secondary-800 dark:text-secondary-100 dark:hover:bg-secondary-800/80',
-        ghost:
-          'hover:bg-slate-100 hover:text-slate-900 dark:hover:bg-slate-800 dark:hover:text-slate-50',
-        link: 'text-slate-500 underline-offset-4 hover:underline dark:text-slate-50',
+          'border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground',
+        secondary: 'bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80',
+        ghost: 'hover:bg-accent hover:text-accent-foreground',
+        link: 'text-primary underline-offset-4 hover:underline',
       },
       size: {
-        default: 'h-10 px-4 py-2',
-        xs: 'h-7 rounded px-2',
-        sm: 'h-9 rounded-md px-3',
-        lg: 'h-11 rounded-md px-8',
-        icon: 'h-10 w-10',
+        default: 'h-9 px-4 py-2',
+        sm: 'h-8 rounded-md px-3 text-xs',
+        lg: 'h-10 rounded-md px-8',
+        icon: 'h-9 w-9',
       },
     },
     defaultVariants: {

--- a/src/components/inputs/Checkbox.vue
+++ b/src/components/inputs/Checkbox.vue
@@ -27,7 +27,7 @@ watch(checked, (newChecked) => {
       <CheckboxRoot
         :id="id"
         v-model:checked="checked"
-        class="peer size-4 shrink-0 rounded-sm border border-slate-600 ring-offset-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-950 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary-500 data-[state=checked]:text-primary-50 dark:border-primary-900 dark:ring-offset-primary-950 dark:focus-visible:ring-primary-300 dark:data-[state=checked]:bg-primary-400 dark:data-[state=checked]:text-primary-800">
+        class="data-[state=checked]:text-primary-foreground dark:focus-visible:ring-primary-foreground dark:data-[state=checked]:text-primary-foreground peer size-4 shrink-0 rounded-sm border border-slate-600 ring-offset-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary dark:border-primary dark:ring-offset-primary dark:data-[state=checked]:bg-primary">
         <CheckboxIndicator class="flex h-full w-full items-center justify-center text-current">
           <Check class="size-4" />
         </CheckboxIndicator>

--- a/src/components/inputs/Toggle.vue
+++ b/src/components/inputs/Toggle.vue
@@ -35,7 +35,7 @@ const forwarded = useForwardPropsEmits(delegatedProps, emits)
       v-slot="{ checked }"
       :class="
         cn(
-          'peer inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-950 focus-visible:ring-offset-2 focus-visible:ring-offset-white disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary-600 data-[state=unchecked]:bg-primary-300 dark:focus-visible:ring-primary-300 dark:focus-visible:ring-offset-primary-800 dark:data-[state=checked]:bg-primary-900 dark:data-[state=unchecked]:bg-primary-500',
+          'data-[state=unchecked]:bg-primary-foreground dark:focus-visible:ring-primary-foreground peer inline-flex h-6 w-11 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2 focus-visible:ring-offset-white disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary dark:focus-visible:ring-offset-primary dark:data-[state=checked]:bg-primary dark:data-[state=unchecked]:bg-primary',
           props.class,
         )
       ">

--- a/src/components/lumuix/LumuixModeToggle.vue
+++ b/src/components/lumuix/LumuixModeToggle.vue
@@ -11,11 +11,11 @@ const isDark = useDark({
 <template>
   <Toggle v-model="isDark">
     <template #checked>
-      <MoonIcon class="m-auto mt-0.5 size-4 text-primary-900" />
+      <MoonIcon class="m-auto mt-0.5 size-4 text-primary" />
     </template>
 
     <template #not-checked>
-      <SunIcon class="m-auto mt-0.5 size-4 text-primary-900" />
+      <SunIcon class="m-auto mt-0.5 size-4 text-primary" />
     </template>
   </Toggle>
 </template>

--- a/src/components/select/SelectScrollUpButton.vue
+++ b/src/components/select/SelectScrollUpButton.vue
@@ -20,7 +20,7 @@ const forwardedProps = useForwardProps(delegatedProps)
     v-bind="forwardedProps"
     :class="cn('flex cursor-default items-center justify-center py-1', props.class)">
     <slot>
-      <ChevronUp class="size-4 text-primary-900" />
+      <ChevronUp class="size-4 text-primary" />
     </slot>
   </SelectScrollUpButton>
 </template>

--- a/src/components/tabs/TabsItem.vue
+++ b/src/components/tabs/TabsItem.vue
@@ -14,7 +14,7 @@ const props = defineProps<{
     :href="tab.href"
     :class="[
       tab.active
-        ? 'bg-white text-primary-500 hover:bg-opacity-80 dark:bg-slate-950 dark:text-primary-400'
+        ? 'bg-white text-primary hover:bg-opacity-80 dark:bg-slate-950'
         : 'hover:bg-white dark:hover:bg-slate-900',
       cn(
         'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md px-3 py-2 text-sm font-medium ring-offset-white transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-950 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 dark:ring-offset-slate-950 dark:focus-visible:ring-slate-300',

--- a/src/presets/preset.ts
+++ b/src/presets/preset.ts
@@ -10,59 +10,36 @@ export default {
         input: 'hsl(var(--input))',
         ring: 'hsl(var(--ring))',
         background: 'hsl(var(--background))',
+
         primary: {
           DEFAULT: 'hsl(var(--primary))',
-          '50': 'hsl(var(--primary-50))',
-          '100': 'hsl(var(--primary-100))',
-          '200': 'hsl(var(--primary-200))',
-          '300': 'hsl(var(--primary-300))',
-          '400': 'hsl(var(--primary-400))',
-          '500': 'hsl(var(--primary-500))',
-          '600': 'hsl(var(--primary-600))',
-          '700': 'hsl(var(--primary-700))',
-          '800': 'hsl(var(--primary-800))',
-          '900': 'hsl(var(--primary-900))',
-          '950': 'hsl(var(--primary-950))',
+          foreground: 'hsl(var(--primary-foreground))',
         },
+
         secondary: {
           DEFAULT: 'hsl(var(--secondary))',
-          '50': 'hsl(var(--secondary-50))',
-          '100': 'hsl(var(--secondary-100))',
-          '200': 'hsl(var(--secondary-200))',
-          '300': 'hsl(var(--secondary-300))',
-          '400': 'hsl(var(--secondary-400))',
-          '500': 'hsl(var(--secondary-500))',
-          '600': 'hsl(var(--secondary-600))',
-          '700': 'hsl(var(--secondary-700))',
-          '800': 'hsl(var(--secondary-800))',
-          '900': 'hsl(var(--secondary-900))',
-          '950': 'hsl(var(--secondary-950))',
+          foreground: 'hsl(var(--secondary-foreground))',
         },
+
         destructive: {
           DEFAULT: 'hsl(var(--destructive))',
-          '50': 'hsl(var(--destructive-50))',
-          '100': 'hsl(var(--destructive-100))',
-          '200': 'hsl(var(--destructive-200))',
-          '300': 'hsl(var(--destructive-300))',
-          '400': 'hsl(var(--destructive-400))',
-          '500': 'hsl(var(--destructive-500))',
-          '600': 'hsl(var(--destructive-600))',
-          '700': 'hsl(var(--destructive-700))',
-          '800': 'hsl(var(--destructive-800))',
-          '900': 'hsl(var(--destructive-900))',
-          '950': 'hsl(var(--destructive-950))',
+          foreground: 'hsl(var(--destructive-foreground))',
         },
+
         muted: {
           DEFAULT: 'hsl(var(--muted))',
           foreground: 'hsl(var(--muted-foreground))',
         },
+
         accent: {
           DEFAULT: 'hsl(var(--accent))',
         },
+
         popover: {
           DEFAULT: 'hsl(var(--popover))',
           foreground: 'hsl(var(--popover-foreground))',
         },
+
         card: {
           DEFAULT: 'hsl(var(--card))',
           foreground: 'hsl(var(--card-foreground))',

--- a/src/presets/styles.css
+++ b/src/presets/styles.css
@@ -12,49 +12,19 @@
   --popover-foreground: 222.2 47.4% 11.2%;
 
   --border: 214.3 31.8% 91.4%;
-
   --input: 214.3 31.8% 91.4%;
 
-  --primary: 173 80% 40%;
-  --primary-50: 166 76% 97%;
-  --primary-100: 167 85% 89%;
-  --primary-200: 168 84% 78%;
-  --primary-300: 171 77% 64%;
-  --primary-400: 172 66% 50%;
-  --primary-500: 173 80% 40%;
-  --primary-600: 175 84% 32%;
-  --primary-700: 175 77% 26%;
-  --primary-800: 176 69% 22%;
-  --primary-900: 176 61% 19%;
-  --primary-950: 179 84% 10%;
+  --primary: 173 80% 40%;;
+  --primary-foreground: 210 40% 98%;
 
-  --secondary: 215 20% 65%;
-  --secondary-50: 210 40% 98%;
-  --secondary-100: 210 40% 96%;
-  --secondary-200: 214 32% 91%;
-  --secondary-300: 213 27% 84%;
-  --secondary-400: 215 20% 65%;
-  --secondary-500: 215 16% 47%;
-  --secondary-600: 215 19% 35%;
-  --secondary-700: 215 25% 27%;
-  --secondary-800: 217 33% 17%;
-  --secondary-900: 222 47% 11%;
-  --secondary-950: 229 84% 5%;
+  --secondary: 210 40% 96.1%;
+  --secondary-foreground: 222.2 47.4% 11.2%;
 
   --accent: 210 40% 96.1%;
+  --accent-foreground: 222.2 47.4% 11.2%;
 
-  --destructive: 0 84% 60%;
-  --destructive-50: 0 86% 97%;
-  --destructive-100: 0 93% 94%;
-  --destructive-200: 0 96% 89%;
-  --destructive-300: 0 94% 82%;
-  --destructive-400: 0 91% 71%;
-  --destructive-500: 0 84% 60%;
-  --destructive-600: 0 72% 51%;
-  --destructive-700: 0 72% 51%;
-  --destructive-800: 0 70% 35%;
-  --destructive-900: 0 63% 31%;
-  --destructive-950: 0 75% 15%;
+  --destructive: 0 100% 50%;
+  --destructive-foreground: 210 40% 98%;
 
   --ring: 215 20.2% 65.1%;
 


### PR DESCRIPTION
This PR basically moves to the original intent of shadcn, using variables such as `primary` rather than our version `primary-{x}(x: 50-950)`. This means a lot of extra work when setting up the package when we can just define the main primary for the package (buttons and badges / whatever else we use it for)