### PR TITLE
Feat/Button Spinner

### DIFF
--- a/app/views/components/Button.vue
+++ b/app/views/components/Button.vue
@@ -6,7 +6,7 @@ import { Button } from '@/components/button'
   <div>The Button can take many forms using the variant prop</div>
 
   <div class="flex w-fit flex-col gap-y-2">
-    <Button> Default </Button>
+    <Button loading> Default </Button>
     <Button variant="primary"> Primary </Button>
     <Button
       variant="destructive"

--- a/app/views/components/Button.vue
+++ b/app/views/components/Button.vue
@@ -30,7 +30,8 @@ import { Button } from '@/components/button'
     </Button>
     <Button
       variant="primary"
-      size="xxl">
+      size="xxl"
+      loading>
       Register
     </Button>
   </div>

--- a/src/components/button/Button.vue
+++ b/src/components/button/Button.vue
@@ -1,13 +1,16 @@
 <script setup lang="ts">
+import { LoaderCircleIcon } from 'lucide-vue-next'
 import type { HTMLAttributes } from 'vue'
-import { cn } from '@/lib/utils'
 import { Primitive, type PrimitiveProps } from 'radix-vue'
+import { cn } from '@/lib/utils'
 import { type ButtonVariants, buttonVariants } from '.'
 
 interface Props extends PrimitiveProps {
   variant?: ButtonVariants['variant']
   size?: ButtonVariants['size']
   class?: HTMLAttributes['class']
+  loading?: boolean
+  spinner?: ButtonVariants['spinner']
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -21,5 +24,8 @@ const props = withDefaults(defineProps<Props>(), {
     :as-child="asChild"
     :class="cn(buttonVariants({ variant, size }), props.class)">
     <slot />
+    <LoaderCircleIcon
+      v-if="loading"
+      :class="cn(buttonVariants({ spinner }), 'animate-spin')" />
   </Primitive>
 </template>

--- a/src/components/button/Button.vue
+++ b/src/components/button/Button.vue
@@ -3,14 +3,13 @@ import { LoaderCircleIcon } from 'lucide-vue-next'
 import type { HTMLAttributes } from 'vue'
 import { Primitive, type PrimitiveProps } from 'radix-vue'
 import { cn } from '@/lib/utils'
-import { type ButtonVariants, buttonVariants } from '.'
+import { type ButtonVariants, spinnerSize, buttonVariants } from '.'
 
 interface Props extends PrimitiveProps {
   variant?: ButtonVariants['variant']
   size?: ButtonVariants['size']
   class?: HTMLAttributes['class']
   loading?: boolean
-  spinner?: ButtonVariants['spinner']
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -26,6 +25,6 @@ const props = withDefaults(defineProps<Props>(), {
     <slot />
     <LoaderCircleIcon
       v-if="loading"
-      :class="cn(buttonVariants({ spinner }), 'animate-spin')" />
+      :class="spinnerSize({ size: size })" />
   </Primitive>
 </template>

--- a/src/components/button/index.ts
+++ b/src/components/button/index.ts
@@ -26,10 +26,19 @@ export const buttonVariants = cva(
         xxl: 'h-14 rounded-lg px-16 text-2xl',
         icon: 'h-9 w-9',
       },
+      spinner: {
+        default: 'size-9',
+        xs: 'size-6',
+        sm: 'size-8',
+        lg: 'size-10',
+        xl: 'size-12',
+        xxl: 'size-14',
+      },
     },
     defaultVariants: {
       variant: 'default',
       size: 'default',
+      spinner: 'default',
     },
   },
 )

--- a/src/components/button/index.ts
+++ b/src/components/button/index.ts
@@ -2,6 +2,26 @@ import { cva, type VariantProps } from 'class-variance-authority'
 
 export { default as Button } from './Button.vue'
 
+export const spinnerSize = cva(
+  'animate-spin',
+  {
+    variants: {
+      size: {
+        // requires ! due to parent sizing from the Button
+        default: '!size-4',
+        xs: '!size-3',
+        sm: '!size-3',
+        lg: '!size-4',
+        xl: '!size-5',
+        xxl: '!size-6',
+        icon: '!size-5'
+      },
+    },
+    defaultVariants: {
+      size: 'default'
+    }
+  }
+)
 export const buttonVariants = cva(
   'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
   {
@@ -26,19 +46,10 @@ export const buttonVariants = cva(
         xxl: 'h-14 rounded-lg px-16 text-2xl',
         icon: 'h-9 w-9',
       },
-      spinner: {
-        default: 'size-9',
-        xs: 'size-6',
-        sm: 'size-8',
-        lg: 'size-10',
-        xl: 'size-12',
-        xxl: 'size-14',
-      },
     },
     defaultVariants: {
       variant: 'default',
       size: 'default',
-      spinner: 'default',
     },
   },
 )


### PR DESCRIPTION
Adds support for a button spinner when the `loading` props is passed. Ideally the spinner should have a style inline with the size of button (via the API) to avoid inconsistent sizing on different button sizes