### PR TITLE
34 support sizes for badges improve styling

### DIFF
--- a/app/views/components/Badge.vue
+++ b/app/views/components/Badge.vue
@@ -15,7 +15,7 @@ const sizes = ['xs', 'sm', 'md', 'lg'] as const
     <template v-for="variant in variants" :key="variant">
       <div class="flex gap-2">
         <template v-for="size in sizes" :key="`${variant}-${size}`">
-          <Badge :variant="variant" :size="size">{{ variant }}</Badge>
+          <Badge :variant="variant" :size="size" type="outline">{{ variant }}</Badge>
         </template>
       </div>
     </template>

--- a/app/views/components/Badge.vue
+++ b/app/views/components/Badge.vue
@@ -1,5 +1,8 @@
 <script setup lang="ts">
 import { Badge } from '@/components/badge'
+
+const variants = ['primary', 'secondary', 'destructive', 'warning'] as const
+const sizes = ['xs', 'sm', 'md', 'lg'] as const
 </script>
 
 <template>
@@ -7,11 +10,25 @@ import { Badge } from '@/components/badge'
     The Badge can take many forms using the variant prop
   </p>
 
-  <div class="flex gap-x-2">
-    <Badge> Default </Badge>
-    <Badge variant="primary"> Primary </Badge>
-    <Badge variant="destructive"> Destructive </Badge>
-    <Badge variant="secondary"> Secondary </Badge>
-    <Badge variant="outline"> Outline </Badge>
+  <h2>Outline</h2>
+  <div class="flex flex-col gap-2 w-1/2">
+    <template v-for="variant in variants" :key="variant">
+      <div class="flex gap-2">
+        <template v-for="size in sizes" :key="`${variant}-${size}`">
+          <Badge :variant="variant" :size="size">{{ variant }}</Badge>
+        </template>
+      </div>
+    </template>
+  </div>
+
+  <h2>Fill</h2>
+  <div class="flex flex-col gap-2 w-1/2">
+    <template v-for="variant in variants" :key="variant">
+      <div class="flex gap-2">
+        <template v-for="size in sizes" :key="`${variant}-${size}-fill`">
+          <Badge :variant="variant" :size="size" type="fill">{{ variant }}</Badge>
+        </template>
+      </div>
+    </template>
   </div>
 </template>

--- a/src/components/badge/Badge.vue
+++ b/src/components/badge/Badge.vue
@@ -5,12 +5,14 @@ import { type BadgeVariants, badgeVariants } from '.'
 
 const props = defineProps<{
   variant?: BadgeVariants['variant']
+  type?: BadgeVariants['type']
+  size?: BadgeVariants['size']
   class?: HTMLAttributes['class']
 }>()
 </script>
 
 <template>
-  <div :class="cn(badgeVariants({ variant }), props.class)">
+  <div :class="cn(badgeVariants({ variant, type, size }), props.class)">
     <slot />
   </div>
 </template>

--- a/src/components/badge/index.ts
+++ b/src/components/badge/index.ts
@@ -3,19 +3,36 @@ import { cva, type VariantProps } from 'class-variance-authority'
 export { default as Badge } from './Badge.vue'
 
 export const badgeVariants = cva(
-  'inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 cursor-default',
+  'inline-flex items-center rounded-full border font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 cursor-default',
   {
     variants: {
       variant: {
-        default: 'border-transparent bg-slate-800 text-slate-50 ',
-        primary: 'border-transparent bg-primary text-primary-foreground ',
-        secondary: 'border-transparent bg-secondary text-secondary-foreground',
-        destructive: 'border-transparent bg-destructive text-destructive-foreground',
-        outline: 'text-foreground',
+        primary: 'border bg-primary text-primary-foreground',
+        secondary: 'border bg-secondary text-secondary-foreground',
+        destructive: 'border bg-destructive text-destructive-foreground',
+        warning: 'border bg-warning text-warning-foreground',
+      },
+      type: {
+        outline: '',
+        fill: 'border-transparent',
+      },
+      size: {
+        xs: 'h-fit px-2 text-xs text-xs',
+        sm: 'h-fit px-2.5 py-0.5 text-sm',
+        md: 'h-fit px-2.5 py-1 text-base',
+        lg: 'h-fit px-3 py-1 text-lg',
       },
     },
+    compoundVariants: [
+      { type: 'outline', variant: 'primary', class: 'border-primary bg-primary/10 text-primary' },
+      { type: 'outline', variant: 'secondary', class: 'border-secondary bg-secondary/10 text-secondary' },
+      { type: 'outline', variant: 'destructive', class: 'border-destructive bg-destructive/20 text-destructive' },
+      { type: 'outline', variant: 'warning', class: 'border-warning bg-warning/20 text-warning' },
+    ],
     defaultVariants: {
-      variant: 'default',
+      variant: 'primary',
+      type: 'outline',
+      size: 'md'
     },
   },
 )

--- a/src/components/badge/index.ts
+++ b/src/components/badge/index.ts
@@ -31,7 +31,7 @@ export const badgeVariants = cva(
     ],
     defaultVariants: {
       variant: 'primary',
-      type: 'outline',
+      type: 'fill',
       size: 'md'
     },
   },

--- a/src/components/badge/index.ts
+++ b/src/components/badge/index.ts
@@ -3,24 +3,24 @@ import { cva, type VariantProps } from 'class-variance-authority'
 export { default as Badge } from './Badge.vue'
 
 export const badgeVariants = cva(
-  'inline-flex items-center rounded-full border font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 cursor-default',
+  'inline-flex items-center rounded-full border h-fit font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 cursor-default',
   {
     variants: {
       variant: {
-        primary: 'border bg-primary text-primary-foreground',
-        secondary: 'border bg-secondary text-secondary-foreground',
-        destructive: 'border bg-destructive text-destructive-foreground',
-        warning: 'border bg-warning text-warning-foreground',
+        primary: 'bg-primary text-primary-foreground',
+        secondary: 'bg-secondary text-secondary-foreground',
+        destructive: 'bg-destructive text-destructive-foreground',
+        warning: 'bg-warning text-warning-foreground',
       },
       type: {
         outline: '',
         fill: 'border-transparent',
       },
       size: {
-        xs: 'h-fit px-2 text-xs text-xs',
-        sm: 'h-fit px-2.5 py-0.5 text-sm',
-        md: 'h-fit px-2.5 py-1 text-base',
-        lg: 'h-fit px-3 py-1 text-lg',
+        xs: 'px-2 text-xs text-xs',
+        sm: 'px-2.5 py-0.5 text-sm',
+        md: 'px-2.5 py-1 text-base',
+        lg: 'px-3 py-1 text-lg',
       },
     },
     compoundVariants: [

--- a/src/presets/preset.ts
+++ b/src/presets/preset.ts
@@ -24,6 +24,11 @@ export default {
           foreground: 'hsl(var(--primary-foreground))',
         },
 
+        warning: {
+          DEFAULT: 'hsl(var(--warning))',
+          foreground: 'hsl(var(--warning-foreground))',
+        },
+
         secondary: {
           DEFAULT: 'hsl(var(--secondary))',
           foreground: 'hsl(var(--secondary-foreground))',

--- a/src/presets/slate.css
+++ b/src/presets/slate.css
@@ -27,8 +27,11 @@
   --primary: 173 80% 40%;
   --primary-foreground: 210 40% 98%;
 
-  --secondary: 210 40% 96.1%;
-  --secondary-foreground: 222.2 47.4% 11.2%;
+  --warning: 45 93% 47%; /* yellow-500 */
+  --warning-foreground: 55 92% 95%; /* yellow-50 */
+
+  --secondary: 217 33% 17%; /* slate-800 */
+  --secondary-foreground: 210 40% 98%; /* slate-50 */
 
   --accent: 210 40% 96.1%;
   --accent-foreground: 222.2 47.4% 11.2%;
@@ -77,8 +80,11 @@
   --primary: 175 77% 26%; /* teal-700 */
   --primary-foreground: 210 40% 98%; /* slate-50 */
 
-  --secondary: 215 20% 65%; /* slate-400 */
-  --secondary-foreground: 229 84% 5%; /* slate-950 */
+  --warning: 35 92% 33%; /* yellow-700 */
+  --warning-foreground: 55 92% 95%; /* yellow-50 */
+
+  --secondary: 215 19% 35%; /* slate-800 */
+  --secondary-foreground: 210 40% 98%; /* slate-50 */
 
   --accent: 215 25% 27%; /* slate-800 */
   --accent-foreground: 222.2 47.4% 11.2%;


### PR DESCRIPTION
Major Improvements to Badge:
1. Remove default
2. Improve secondary colour scheme (globally)
3. Add warning variant
4. Support sizes (xs, sm, md, lg)
5. Support type (fill, outline) - using the compoundVariants I can adjust styles for the outline

![image](https://github.com/user-attachments/assets/d5442f98-970a-449c-be77-c7350d455176)
