### PR TITLE
Pagination refactor

### DIFF
--- a/app/views/components/Lumuix.vue
+++ b/app/views/components/Lumuix.vue
@@ -77,10 +77,10 @@ const tabs = [
 
 const paginatedData = {
   data: [],
-  current_page: 2,
+  current_page: 5,
   first_page_url: '?page=1',
   from: 1,
-  last_page: 5,
+  last_page: 6,
   last_page_url: '?page=7',
   links: [
     {
@@ -89,7 +89,7 @@ const paginatedData = {
       url: '?page=1',
     },
     {
-      active: true,
+      active: false,
       label: '2',
       url: '?page=2',
     },
@@ -104,25 +104,25 @@ const paginatedData = {
       url: '?page=4',
     },
     {
-      active: false,
+      active: true,
       label: '5',
       url: '?page=5',
     },
     {
       active: false,
-      label: '5',
+      label: '6',
       url: '?page=6',
     },
     {
       active: false,
-      label: '5',
+      label: '7',
       url: '?page=7',
     },
   ],
-  next_page_url: '?page=3',
+  next_page_url: '?page=6',
   path: '#',
   per_page: 2,
-  prev_page_url: '?page=1',
+  prev_page_url: '?page=5',
   to: 2,
   total: 10,
 }
@@ -187,7 +187,7 @@ const isOpen = ref(false)
         </LumuixTabs>
       </div>
 
-      <div>
+      <div class="mx-4">
         <LumuixPagination
           :as="Link"
           :data="paginatedData" />

--- a/app/views/components/Lumuix.vue
+++ b/app/views/components/Lumuix.vue
@@ -77,7 +77,7 @@ const tabs = [
 
 const paginatedData = {
   data: [],
-  current_page: 5,
+  current_page: 4,
   first_page_url: '?page=1',
   from: 1,
   last_page: 6,
@@ -99,12 +99,12 @@ const paginatedData = {
       url: '?page=3',
     },
     {
-      active: false,
+      active: true,
       label: '4',
       url: '?page=4',
     },
     {
-      active: true,
+      active: false,
       label: '5',
       url: '?page=5',
     },

--- a/app/views/components/Pagination.vue
+++ b/app/views/components/Pagination.vue
@@ -22,8 +22,8 @@ import { Button } from '@/components/button'
     <PaginationList
       v-slot="{ items }"
       class="flex items-center gap-1">
-      <PaginationFirst />
-      <PaginationPrev />
+      <PaginationFirst href="#" />
+      <PaginationPrev href="#" />
 
       <template v-for="(item, index) in items">
         <PaginationListItem
@@ -43,8 +43,8 @@ import { Button } from '@/components/button'
           :index="index" />
       </template>
 
-      <PaginationNext />
-      <PaginationLast />
+      <PaginationNext href="#" />
+      <PaginationLast href="#" />
     </PaginationList>
   </Pagination>
 </template>

--- a/src/components/lumuix/LumuixPagination.vue
+++ b/src/components/lumuix/LumuixPagination.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { computed } from 'vue'
 import { Button } from '@/components/button'
 import {
   Pagination,
@@ -43,6 +44,9 @@ const getTotalNumber = () => {
 
   return props.data.current_page * props.data.per_page
 }
+
+const currentActiveIndex = computed(() => props.data.links.findIndex((link) => link.active))
+console.log(currentActiveIndex.value)
 </script>
 
 <template>
@@ -65,7 +69,7 @@ const getTotalNumber = () => {
 
         <template v-for="(item, index) in data.links">
             <Button
-              v-if="index < 5"
+              v-if="(index <= currentActiveIndex+2) && (index >= currentActiveIndex-2)"
               :key="index"
               as-child
               class="size-10 p-0"
@@ -76,7 +80,7 @@ const getTotalNumber = () => {
             </Button>
         </template>
 
-        <PaginationEllipsis v-if="data.links.length > 5" />
+        <PaginationEllipsis v-if="currentActiveIndex < data.links.length-2" />
 
         <PaginationNext
           v-if="data.next_page_url"

--- a/src/components/lumuix/LumuixPagination.vue
+++ b/src/components/lumuix/LumuixPagination.vue
@@ -46,7 +46,6 @@ const getTotalNumber = () => {
 }
 
 const currentActiveIndex = computed(() => props.data.links.findIndex((link) => link.active))
-console.log(currentActiveIndex.value)
 </script>
 
 <template>

--- a/src/components/lumuix/LumuixPagination.vue
+++ b/src/components/lumuix/LumuixPagination.vue
@@ -56,27 +56,24 @@ const getTotalNumber = () => {
       <PaginationList class="flex items-center gap-1">
         <PaginationFirst
           :as="as"
-          as-child
           :href="data.first_page_url" />
 
         <PaginationPrev
           v-if="data.prev_page_url"
           :as="as"
-          as-child
           :href="data.prev_page_url" />
 
         <template v-for="(item, index) in data.links">
-          <div
-            v-if="index < 5"
-            :key="index">
             <Button
-              :href="item.url"
-              :as="as"
+              v-if="index < 5"
+              :key="index"
+              as-child
               class="size-10 p-0"
               :variant="item.active ? 'primary' : 'outline'">
-              {{ item.label }}
+              <component :is="as" :href="item.url">
+                {{ item.label }}
+              </component>
             </Button>
-          </div>
         </template>
 
         <PaginationEllipsis v-if="data.links.length > 5" />
@@ -84,12 +81,10 @@ const getTotalNumber = () => {
         <PaginationNext
           v-if="data.next_page_url"
           :as="as"
-          as-child
           :href="data.next_page_url" />
 
         <PaginationLast
           :as="as"
-          as-child
           :href="data.last_page_url" />
       </PaginationList>
     </Pagination>

--- a/src/components/pagination/PaginationFirst.vue
+++ b/src/components/pagination/PaginationFirst.vue
@@ -8,13 +8,11 @@ import { Button } from '@/components/button'
 const props = withDefaults(
   defineProps<
     PaginationFirstProps & {
+      href: string
       class?: HTMLAttributes['class']
-      as?: any
     }
   >(),
-  {
-    asChild: true,
-  },
+  {}
 )
 
 const delegatedProps = computed(() => {
@@ -28,10 +26,12 @@ const delegatedProps = computed(() => {
   <PaginationFirst v-bind="delegatedProps">
     <Button
       :class="cn('size-10 p-0', props.class)"
-      :as="as"
+      as-child
       variant="outline">
       <slot>
-        <ChevronsLeft class="size-4" />
+        <component :is="as" :href="href">
+            <ChevronsLeft class="size-4" />
+        </component>
       </slot>
     </Button>
   </PaginationFirst>

--- a/src/components/pagination/PaginationLast.vue
+++ b/src/components/pagination/PaginationLast.vue
@@ -8,13 +8,11 @@ import { Button } from '@/components/button'
 const props = withDefaults(
   defineProps<
     PaginationLastProps & {
+      href: string
       class?: HTMLAttributes['class']
-      as?: any
     }
   >(),
-  {
-    asChild: true,
-  },
+  {},
 )
 
 const delegatedProps = computed(() => {
@@ -28,10 +26,12 @@ const delegatedProps = computed(() => {
   <PaginationLast v-bind="delegatedProps">
     <Button
       :class="cn('size-10 p-0', props.class)"
-      :as="as"
+      as-child
       variant="outline">
       <slot>
-        <ChevronsRight class="size-4" />
+        <component :is="as" :href="href">
+          <ChevronsRight class="size-4" />
+        </component>
       </slot>
     </Button>
   </PaginationLast>

--- a/src/components/pagination/PaginationNext.vue
+++ b/src/components/pagination/PaginationNext.vue
@@ -8,13 +8,11 @@ import { Button } from '@/components/button'
 const props = withDefaults(
   defineProps<
     PaginationNextProps & {
+      href: string
       class?: HTMLAttributes['class']
-      as?: any
     }
   >(),
-  {
-    asChild: true,
-  },
+  {}
 )
 
 const delegatedProps = computed(() => {
@@ -28,10 +26,12 @@ const delegatedProps = computed(() => {
   <PaginationNext v-bind="delegatedProps">
     <Button
       :class="cn('size-10 p-0', props.class)"
-      :as="as"
+      as-child
       variant="outline">
       <slot>
-        <ChevronRight class="size-4" />
+        <component :is="as" :href="href">
+          <ChevronRight class="size-4" />
+        </component>
       </slot>
     </Button>
   </PaginationNext>

--- a/src/components/pagination/PaginationPrev.vue
+++ b/src/components/pagination/PaginationPrev.vue
@@ -8,13 +8,11 @@ import { Button } from '@/components/button'
 const props = withDefaults(
   defineProps<
     PaginationPrevProps & {
+      href: string
       class?: HTMLAttributes['class']
-      as?: any
     }
   >(),
-  {
-    asChild: true,
-  },
+  {}
 )
 
 const delegatedProps = computed(() => {
@@ -28,10 +26,12 @@ const delegatedProps = computed(() => {
   <PaginationPrev v-bind="delegatedProps">
     <Button
       :class="cn('size-10 p-0', props.class)"
-      :as="as"
+      as-child
       variant="outline">
       <slot>
-        <ChevronLeft class="size-4" />
+        <component :is="as" :href="href">
+          <ChevronLeft class="size-4" />
+        </component>
       </slot>
     </Button>
   </PaginationPrev>


### PR DESCRIPTION
Improves LumuixPagination to show 2 links (pages) either side of current active page, rather then being hard coded to the first 5. Also makes some improvements to the pagination components, removing the `as` prop as its already defined in `PaginationLastProps`, was also getting a weird error `TypeError: Cannot read properties of null (reading 'method')` not sure if this is related...